### PR TITLE
Fix SpaBLL data loading

### DIFF
--- a/Built/SpaBLL.cs
+++ b/Built/SpaBLL.cs
@@ -190,8 +190,7 @@ namespace BLLSPA
         }
         public void LoadDuLieu()
         {
-            SpaDAL dal = new SpaDAL();
-            danhSach = dal.DocTuFileXML("DanhSachKhachHang.xml");
+            danhSach = dal.DocTuFileXML(filePath);
         }
     }
 }


### PR DESCRIPTION
## Summary
- clean up `LoadDuLieu` so it uses the class `SpaDAL` instance and the predefined file path

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858e34fb410832794022099d49478fc